### PR TITLE
Add eups, use matplotlib-base

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "rubin-env" %}
-{% set version = "0.1.0" %}
-{% set build_number = 1 %}
+{% set version = "0.1.1" %}
+{% set build_number = 0 %}
 
 package:
   name: {{ name }}
@@ -50,6 +50,7 @@ requirements:
     - boost =1.70
     - cfitsio
     - eigen
+    - eups
     - galsim
     - libaprutil
     - log4cxx
@@ -81,7 +82,7 @@ requirements:
     - healpy
     - lmfit
     - lsstdesc.coord
-    - matplotlib
+    - matplotlib-base
     - moto
     - mpi4py
     - ndarray
@@ -92,7 +93,6 @@ requirements:
     - psycopg2
     - pyarrow
     - pybind11 <2.3
-    - pyqt <5.12  # [linux64]
     - pytables
     - python =3.7
     - pyyaml


### PR DESCRIPTION
Adds eups to the recipe. Uses matplotlib-base to avoid pyqt on linux.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
