### PR TITLE
Update to python 3.8. Remove mpich restriction

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rubin-env" %}
-{% set version = "0.1.2" %}
+{% set version = "0.1.3" %}
 {% set build_number = 0 %}
 
 package:
@@ -56,7 +56,7 @@ requirements:
     - libaprutil
     - log4cxx
     - minuit2
-    - mpich =3.2.1
+    - mpich
     - starlink-ast
     - wcslib
     - xpa
@@ -95,7 +95,7 @@ requirements:
     - pyarrow
     - pybind11 =2.5
     - pytables
-    - python =3.7
+    - python =3.8
     - pyyaml
     - requests
     - scikit-image


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

mpich is removed because it may be tough to get a solution otherwise. This may break jobs against slurm verification cluster at NCSA (mpich 3.3 regression fixed in yet-to-be-released mpich 3.4) but should be fine otherwise.

