### PR TITLE
DM-33380: Create rubin-env 1.0.0.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "rubin-env" %}
-{% set version = "0.7.0" %}
-{% set build_number = 4 %}
+{% set version = "1.0.0" %}
+{% set build_number = 0 %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,7 @@ outputs:
         - eigen =3.3
         - eups
         - firefly-client
-        - galsim =2.2
+        - galsim
         - libaprutil =1
         # there is some issue with pex_exceptions with clang 11 and libcxx 12
         # until it is tracked down, it makes sense to keep these at the same
@@ -86,7 +86,7 @@ outputs:
         - conda
         - configparser
         - cffi =1
-        - click <8
+        - click
         - coloredlogs
         - cython =0
         - deprecated
@@ -115,7 +115,7 @@ outputs:
         - networkx <2.6
         - numexpr =2
         - numpy =1.20
-        - pandas <1.3
+        - pandas
         - pgcli
         - photutils >=0.7
         - piff
@@ -130,12 +130,12 @@ outputs:
         - pyyaml
         - requests
         - schwimmbad
-        - scikit-image <0.18|>0.18.3
+        - scikit-image !=0.18
         - scikit-learn
         - scipy
         - seaborn
         - sqlalchemy <2
-        - sqlite <3.35
+        - sqlite
         - tqdm
         - treecorr =4
         - ws4py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -109,7 +109,7 @@ outputs:
         - lmfit !=1.0.3
         - lsstdesc.coord
         - matplotlib-base
-        - moto <3
+        - moto
         - mpi4py
         - ndarray =1
         - networkx

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -101,8 +101,8 @@ outputs:
         - h5py
         - healpy
         - healsparse
-        - idds-client
-        - idds-doma
+        - idds-client >=0.9.5
+        - idds-doma >=0.9.5
         # inflection may go away in the future; see DM-32591
         - inflection
         - iminuit >=2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,30 +21,30 @@ outputs:
     requirements:
       run:
         # jq is special - it is needed for the pin-it utility in this package
-        - jq >=1.6
+        - jq
         # build-like dependencies
         # As part of our scons build process, we do run tests, so
         # these really are required to perform a build.
         # Note that "testing" in conda-forge should be limited to testing
         # successful packaging, and not testing code.
-        - compilers >=1.2
-        - cmake >=3.21
-        - doxygen >=1.9
+        - compilers
+        - cmake
+        - doxygen
         - flake8 =3.8.4
-        - make >=4.3
-        - pep8-naming >=0.11
-        - pip >=21.3
-        - psutil >=5.8
-        - pytest >=6.2
-        - pytest-cov >=3.0
-        - pytest-doctestplus >=0.11
-        - pytest-flake8 >=1.0
-        - pytest-openfiles >=0.5
-        - pytest-runner >=5.3
-        - pytest-session2file >=0.1
-        - pytest-subtests >=0.5
-        - pytest-xdist >=2.4
-        - scons >=4.2
+        - make
+        - pep8-naming
+        - pip
+        - psutil
+        - pytest
+        - pytest-cov
+        - pytest-doctestplus
+        - pytest-flake8
+        - pytest-openfiles
+        - pytest-runner
+        - pytest-session2file
+        - pytest-subtests
+        - pytest-xdist
+        - scons
         # host-like and run-like
         # These are mostly run-like, but for the same reasons as
         # above, we need most of these at build time, so they are mostly
@@ -52,8 +52,8 @@ outputs:
         - boost =1.74
         - cfitsio =3
         - eigen =3.3
-        - eups >=2.2.3
-        - firefly-client >=2.8
+        - eups
+        - firefly-client
         - galsim =2.2
         - libaprutil =1
         # there is some issue with pex_exceptions with clang 11 and libcxx 12
@@ -61,69 +61,69 @@ outputs:
         # major version
         - libcxx =={{ cxx_compiler_version }}.*  # [osx]
         - log4cxx =0
-        - lsst-documenteer-pipelines >=0.6.9
-        - lsst-documenteer-technote >=0.6.9
+        - lsst-documenteer-pipelines
+        - lsst-documenteer-technote
         - minuit2 =6
         - mpich =3
         - starlink-ast =9
         - wcslib =7
         - xpa =2
         # run-like
-        - alembic >=1.7
+        - alembic
         - apr =1
-        - autograd >=1.3
-        - astropy >=4.3
-        - backoff >=1.11
-        - boto3 >=1.19
-        - bottleneck >=1.3
+        - autograd
+        - astropy
+        - backoff
+        - boto3
+        - bottleneck
         # conda is required for runtime inspection of installed software
-        - conda >=4.10
+        - conda
         - cffi =1
-        - click >=7.1,<8
+        - click <8
         - cython =0
-        - deprecated >=1.2
-        - dustmaps >=1.0
-        - esutil >=0.6
-        - fastavro >=1.4
-        - future >=0.18
-        - git >=2.33
-        - git-lfs >=3.0
+        - deprecated
+        - dustmaps
+        - esutil
+        - fastavro
+        - future
+        - git
+        - git-lfs
         - gsl =2
-        - h5py >=3.4
-        - healpy >=1.15
-        - healsparse >=1.4
-        - idds-client >=0.9.5
-        - idds-doma >=0.9.5
+        - h5py
+        - healpy
+        - healsparse
+        - idds-client
+        - idds-doma
         # inflection may go away in the future; see DM-32591
-        - inflection >=0.5
-        - lmfit >=1.0,!=1.0.3
-        - lsstdesc.coord >=1.2
-        - matplotlib-base >=3.4
-        - moto >=2.2,<3
-        - mpi4py >=3.1
+        - inflection
+        - lmfit !=1.0.3
+        - lsstdesc.coord
+        - matplotlib-base
+        - moto <3
+        - mpi4py
         - ndarray =1
-        - networkx >=2.5,<2.6
+        - networkx <2.6
         - numexpr =2
         - numpy =1.20
-        - pandas >=1.2,<1.3
-        - pgcli >=3.2
-        - piff >=1.0
+        - pandas <1.3
+        - pgcli
+        - piff
         - psycopg2 =2
-        - pyarrow >=5.0
-        - pybind11 >=2.8
-        - pydantic >=1.8
-        - pytables >=3.6
+        - pyarrow
+        - pybind11
+        - pydantic
+        - pytables
         - python =3.8
-        - pyyaml >=6.0
-        - requests >=2.26
-        - scikit-image >=0.17,<0.18
-        - scikit-learn >=1.0
-        - scipy >=1.7
-        - seaborn >=0.11
-        - sqlalchemy >=1.4,<2
-        - sqlite >=3.34.0,<3.35
+        - pyyaml
+        - requests
+        - scikit-image <0.18
+        - scikit-learn
+        - scipy
+        - seaborn
+        - sqlalchemy <2
+        - sqlite <3.35
         - treecorr =4
-        - ws4py >=0.5
+        - ws4py
 
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,9 +29,12 @@ outputs:
         # successful packaging, and not testing code.
         - compilers
         - cmake
+        - coverage >=3.6
+        - coveralls
         - doxygen
         - flake8 =3.8.4
         - make
+        - nose
         - pep8-naming
         - pip
         - psutil
@@ -60,29 +63,35 @@ outputs:
         # until it is tracked down, it makes sense to keep these at the same
         # major version
         - libcxx =={{ cxx_compiler_version }}.*  # [osx]
+        - llvmlite
         - log4cxx =0
         - lsst-documenteer-pipelines
         - lsst-documenteer-technote
         - minuit2 =6
         - mpich =3
+        - numba
         - starlink-ast =9
         - wcslib =7
         - xpa =2
         # run-like
         - alembic
         - apr =1
-        - autograd
         - astropy
+        - astroquery
+        - autograd
         - backoff
         - boto3
         - bottleneck
         # conda is required for runtime inspection of installed software
         - conda
+        - configparser
         - cffi =1
         - click <8
+        - coloredlogs
         - cython =0
         - deprecated
         - dustmaps
+        - emcee
         - esutil
         - fastavro
         - future
@@ -96,6 +105,7 @@ outputs:
         - idds-doma
         # inflection may go away in the future; see DM-32591
         - inflection
+        - iminuit >=2
         - lmfit !=1.0.3
         - lsstdesc.coord
         - matplotlib-base
@@ -107,21 +117,25 @@ outputs:
         - numpy =1.20
         - pandas <1.3
         - pgcli
+        - photutils >=0.7
         - piff
         - psycopg2 =2
         - pyarrow
         - pybind11
         - pydantic
+        - pysynphot
         - pytables
         - python =3.8
         - pyyaml
         - requests
-        - scikit-image <0.18
+        - schwimmbad
+        - scikit-image <0.18|>0.18.3
         - scikit-learn
         - scipy
         - seaborn
         - sqlalchemy <2
         - sqlite <3.35
+        - tqdm
         - treecorr =4
         - ws4py
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -119,6 +119,7 @@ outputs:
         - pgcli
         - photutils >=0.7
         - piff
+        - prmon  # [linux]
         - psycopg2 =2
         - pyarrow
         - pybind11

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -112,7 +112,7 @@ outputs:
         - moto <3
         - mpi4py
         - ndarray =1
-        - networkx <2.6
+        - networkx
         - numexpr =2
         - numpy =1.20
         - pandas


### PR DESCRIPTION
- Add minimum pins for IDDS components (already proposed as 0.7.1).
- Remove pins from click, galsim, pandas, networkx, and sqlite as documented on https://confluence.lsstcorp.org/display/DM/DM+Third+Party+Software; adjust scikit-image pin to allow new releases.
- Add requested dependencies for Spectractor (RFC-800).
- Add prmon for PanDA batch process monitoring (DM-32579, restricted to Linux-only).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
