### PR TITLE
Break out rubin-env-rsp and make -extras inherit from it

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "rubin-env" %}
 {% set version = "4.1.0dev" %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 
 package:
   name: {{ name }}
@@ -204,7 +204,7 @@ outputs:
         - '[ $(echo __GXX_ABI_VERSION | ${CXX} -E - | tail -1) == 1014 ]'  # [linux]
         - '[ $(echo __GXX_ABI_VERSION | ${CXX} -E - | tail -1) == 1002 ]'  # [osx]
 
-  - name: rubin-env-extras
+  - name: rubin-env-rsp
     requirements:
       host:
         - python
@@ -221,22 +221,17 @@ outputs:
         - bqplot
         - ciso8601  # [not aarch64]
         - cloudpickle
-        - colorcet # sims
         - cookiecutter
-        - cycler # sims
         - dash
         - dask
-        - dask-jobqueue # shared
         - dask-kubernetes
         - dask_labextension
         - datashader
         - distributed
-        - ephem # sims
         - fastparquet
         - ffmpeg # RFC-846
         - freetype-py
         - gcsfs
-        - george # sims  # [not aarch64]
         - geoviews
         - ginga
         - graphviz
@@ -245,11 +240,9 @@ outputs:
         - imagemagick # RFC-846
         - intake
         - intake-parquet
-        - ipdb # shared
         - ipyevents
         - ipykernel
         - ipympl
-        - ipyparallel # sims
         - ipyvolume
         - ipywidgets
         - isort
@@ -264,6 +257,7 @@ outputs:
         - jupyterlab_execute_time
         - jupyterlab_iframe
         - jupyterlab_widgets
+        - mamba
         - mypy
         - mysqlclient
         - nbconvert-webpdf
@@ -271,9 +265,6 @@ outputs:
         - nbval
         - nodejs >=16
         - numba
-        - openorb # sims  # [not aarch64]
-        - openorb-data-de405 # sims  # [not aarch64]
-        - palpy # sims  # [not aarch64]
         - panel # shared
         - papermill
         - paramnb
@@ -281,7 +272,6 @@ outputs:
         - pep8 # shared
         - plotly
         - pre-commit
-        - pyct # shared
         - pyflakes # shared
         - pypandoc
         - pyshp
@@ -299,10 +289,30 @@ outputs:
     test:
       commands:
         # grep pin-it output for yarn dependency
-        - pin-it rubin-env-extras | grep "yarn="
-        # ensure binary compatibility; bump major version if not
-        - '[ $(echo __GXX_ABI_VERSION | ${CXX} -E - | tail -1) == 1014 ]'  # [linux]
-        - '[ $(echo __GXX_ABI_VERSION | ${CXX} -E - | tail -1) == 1002 ]'  # [osx]
+        - pin-it rubin-env-rsp | grep "yarn="
+
+  - name: rubin-env-extras
+    requirements:
+      host:
+        - python
+      run:
+        - {{ pin_subpackage("rubin-env", exact=True) }}
+        - {{ pin_subpackage("rubin-env-rsp", exact=True) }}
+        - colorcet # sims
+        - cycler # sims
+        - dask-jobqueue # shared
+        - ephem # sims
+        - george # sims  # [not aarch64]
+        - ipdb # shared
+        - ipyparallel # sims
+        - openorb # sims  # [not aarch64]
+        - openorb-data-de405 # sims  # [not aarch64]
+        - palpy # sims  # [not aarch64]
+        - pyct # shared
+    test:
+      commands:
+        # grep pin-it output for george dependency
+        - pin-it rubin-env-extras | grep "pyct"
 
 about:
   home: https://github.com/conda-forge/rubinenv-feedstock


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Simplify sciplat-lab construction by creating ruben-env-rsp; make rubin-env-extras inherit -rsp.
<!--
Please add any other relevant info below:
-->
