### PR TITLE
DM-35580: Pin photutils to <1.5.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "rubin-env" %}
 {% set version = "4.0.1" %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 
 package:
   name: {{ name }}
@@ -152,7 +152,8 @@ outputs:
         - {{ pin_compatible('numpy') }}
         - pandas
         - pgcli
-        - photutils >=0.7
+        # Remove < after Spectractor fix: see DM-35580
+        - photutils >=0.7,<1.5
         - piff
         - prmon  # [linux]
         - psycopg2 =2


### PR DESCRIPTION
photutils 1.5.0 enforces an odd-sized filter, causing failures in the
Spectractor tests.  Pin it back for now until the code can be fixed.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
