### PR TITLE
DM-39006: Make importlib_resources and fitsio explicit.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -334,6 +334,7 @@ outputs:
         - pyct
         - pydocstyle
         - pyflakes
+        - pytest-profiling
         - python-build
         - pyvo
         - ripgrep

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "rubin-env" %}
 {% set version = "6.0.0" %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 package:
   name: {{ name }}
@@ -129,6 +129,7 @@ outputs:
         - emcee
         - esutil
         - fastavro
+        - fitsio
         - frozendict >=2.2.0
         - future
         - getcalspec >=2.0.0
@@ -143,6 +144,7 @@ outputs:
         - idds-client >=0.11.0
         - idds-doma >=0.11.0
         - iminuit >=2
+        - importlib_resources
         - lmfit
         - lsstdesc.coord
         - matplotlib-base !=3.6.0,<3.7.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -284,6 +284,7 @@ outputs:
         - pythreejs
         - pyviz_comms
         - pyvo
+        - ripgrep
         - sidecar
         - snappy
         - terminado
@@ -335,6 +336,7 @@ outputs:
         - pyflakes
         - python-build
         - pyvo
+        - ripgrep
         - snakeviz
         - types-deprecated
         - types-pkg_resources


### PR DESCRIPTION
This is for [RFC-922](https://jira.lsstcorp.org/browse/RFC-922) and [RFC-923](https://jira.lsstcorp.org/browse/RFC-923).  These packages were already in the environment, but we are now explicitly depending on them.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
