### PR TITLE
DM-40021: Fix dependency downgrades in rubin-env 7.0.0.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rubin-env" %}
-{% set version = "7.0.0" %}
+{% set version = "7.0.1" %}
 {% set build_number = 0 %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -167,7 +167,6 @@ outputs:
         - pytorch
         - pyyaml
         - requests
-        - rucio-clients <=1.29.12
         - ruff ==0.0.278
         - schwimmbad
         - scikit-image !=0.18
@@ -258,7 +257,7 @@ outputs:
         - jupyter-server-proxy
         - jupyter_bokeh
         - jupyterhub
-        - jupyterlab >=3,<4
+        - jupyterlab >=3.6,<4
         - jupyterlab_execute_time >=2,<3
         - jupyterlab_iframe
         - jupyterlab_widgets
@@ -322,7 +321,7 @@ outputs:
         - isort !=5.11.0
         - jedi
         - jupyter
-        - jupyterlab >=3,<4
+        - jupyterlab >=3.6,<4
         - jupyterlab_server
         - line_profiler
         - lsst-documenteer-pipelines


### PR DESCRIPTION
Removing rucio-clients frees up a number of dependencies. Increasing the minimum pin for jupyterlab ensures proper versions of it and jupyterlab_server for the RSP.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
