### PR TITLE
Remove dash from rsp env

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "rubin-env" %}
 {% set version = "9.0.0" %}
-{% set build_number = 10 %}
+{% set build_number = 11 %}
 
 package:
   name: {{ name }}
@@ -252,7 +252,6 @@ outputs:
         - ciso8601 >=2.3.1
         - cloudpickle >=3.0.0
         - cookiecutter >=2.6.0
-        - dash >=2.17.0
         - dask-core >=2024.5.0
         - datashader >=0.16.0
         - fastparquet >=2024.2.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
dash needs a Lab rebuild, and our Github Actions machine doesn't have enough memory to do that.  I kinda think we don't need dash in the first place, since it's mostly for building standalone applications.