### PR TITLE
Pin astroquery <0.4.8 and fix rerendering

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -39,17 +39,17 @@ gsl:
 libaprutil:
 - '1'
 libblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 libboost_python_devel:
 - '1.82'
 libcblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 libcxx:
 - '16'
 liblapack:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapacke:
-- 3.9 *netlib
+- 3.9.* *netlib
 log4cxx:
 - 1.2.0
 minuit2:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -39,15 +39,15 @@ gsl:
 libaprutil:
 - '1'
 libblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 libboost_python_devel:
 - '1.82'
 libcblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapack:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapacke:
-- 3.9 *netlib
+- 3.9.* *netlib
 log4cxx:
 - 1.2.0
 minuit2:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -39,17 +39,17 @@ gsl:
 libaprutil:
 - '1'
 libblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 libboost_python_devel:
 - '1.82'
 libcblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 libcxx:
 - '16'
 liblapack:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapacke:
-- 3.9 *netlib
+- 3.9.* *netlib
 log4cxx:
 - 1.2.0
 macos_machine:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -39,17 +39,17 @@ gsl:
 libaprutil:
 - '1'
 libblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 libboost_python_devel:
 - '1.82'
 libcblas:
-- 3.9 *netlib
+- 3.9.* *netlib
 libcxx:
 - '16'
 liblapack:
-- 3.9 *netlib
+- 3.9.* *netlib
 liblapacke:
-- 3.9 *netlib
+- 3.9.* *netlib
 log4cxx:
 - 1.2.0
 macos_machine:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -12,10 +12,12 @@ fortran_compiler_version:      # [unix]
 llvm_openmp:                              # [osx]
   - 16                                    # [osx]
 python:
-  # part of a zip_keys: python, python_impl, numpy
+  # part of a zip_keys: python, python_impl, numpy, is_python_min
   - 3.11.* *_cpython
 python_impl:
   - cpython
+is_python_min:
+  - false
 apr:
   - '1'
 cffi:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "rubin-env" %}
 {% set version = "9.0.0" %}
-{% set build_number = 12 %}
+{% set build_number = 13 %}
 
 package:
   name: {{ name }}
@@ -114,7 +114,7 @@ outputs:
         # run-like
         - alembic >=1.13.0
         - astropy >=6.0.0,<6.1.5
-        - astroquery >=0.4.6
+        - astroquery >=0.4.6,<0.4.8
         - autograd >=1.6.2
         - backoff >=2.2.1
         - batoid >=0.7.3


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

This fixes the rerendering problem.  Apparently there is a new required `is_python_min` zip key that needs to go in `conda_build_config.yaml` and it seems that there must be a related migration bug related to this.  cc @beckermr 

<!--
Please add any other relevant info below:
-->
