### PR TITLE
Update starlink_ast and base image from centos to alma9

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,13 +11,13 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
-        SHORT_CONFIG: linux_64_
-      linux_aarch64_:
-        CONFIG: linux_aarch64_
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+        SHORT_CONFIG: linux_64_python3.12.____cpython
+      linux_aarch64_python3.12.____cpython:
+        CONFIG: linux_aarch64_python3.12.____cpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
-        SHORT_CONFIG: linux_aarch64_
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+        SHORT_CONFIG: linux_aarch64_python3.12.____cpython
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,12 +12,12 @@ jobs:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-        SHORT_CONFIG: linux_64_python3.12.____cpython
-      linux_aarch64_python3.12.____cpython:
-        CONFIG: linux_aarch64_python3.12.____cpython
+        SHORT_CONFIG: linux_64_
+      linux_aarch64_:
+        CONFIG: linux_aarch64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-        SHORT_CONFIG: linux_aarch64_python3.12.____cpython
+        SHORT_CONFIG: linux_aarch64_
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -25,7 +25,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:cos7
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 eigen:
 - '3.4'
 fftw:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -69,7 +69,7 @@ python:
 python_impl:
 - cpython
 starlink_ast:
-- 9.2.12
+- 9.2.13
 target_platform:
 - linux-64
 wcslib:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -25,7 +25,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:cos7
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 eigen:
 - '3.4'
 fftw:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -67,7 +67,7 @@ python:
 python_impl:
 - cpython
 starlink_ast:
-- 9.2.12
+- 9.2.13
 target_platform:
 - linux-aarch64
 wcslib:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -71,7 +71,7 @@ python:
 python_impl:
 - cpython
 starlink_ast:
-- 9.2.12
+- 9.2.13
 target_platform:
 - osx-64
 wcslib:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -71,7 +71,7 @@ python:
 python_impl:
 - cpython
 starlink_ast:
-- 9.2.12
+- 9.2.13
 target_platform:
 - osx-arm64
 wcslib:

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -10,7 +10,7 @@ github:
   branch_name: main
   tooling_branch_name: main
 os_version:
-  linux_64: cos7
+  linux_64: alma9
 provider:
   linux_aarch64: default
 test: native_and_emulated

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -43,7 +43,7 @@ minuit2:
 ndarray:
   - '1'
 starlink_ast:
-  - '9.2.12'
+  - '9.2.13'
 wcslib:
   - '8'
 xpa:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -127,7 +127,7 @@ outputs:
         - colour-science >=0.4.6
         - configparser >=7.1.0
         - danish >=0.5.0
-        - deepdiff >=8.2.0
+        - deepdiff >=8.5.0
         - defusedxml >=0.7.1
         - deprecated >=1.2.18
         - dustmaps >=1.0.13

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -179,7 +179,7 @@ outputs:
         - piff >=1.5
         - prmon >=3.1.1  # [linux]
         - psycopg2 >=2.9.9,<3
-        - pyarrow >=17.0.0,<18
+        - pyarrow >=20.0.0
         - pybind11 >=3,<4
         - pydantic >=2.10.1,<3
         - pyld >=2.0.4
@@ -293,6 +293,7 @@ outputs:
         - jupyterlab_execute_time >=3.1.2
         - jupyterlab_iframe >=0.5.0
         - jupyterlab_widgets >=3.0.10
+        - lsdb >=0.6.0
         - lsst-efd-client >=0.12.0
         - mermaid-py >=0.7.0
         - mypy >=1.7.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rubin-env" %}
-{% set version = "10.1.0" %}
+{% set version = "11.0.0" %}
 {% set build_number = 0 %}
 
 package:


### PR DESCRIPTION
- **Update base images to use alma9 over centos**
- **MNT: Re-rendered with conda-build 25.4.2, conda-smithy 3.48.1, and conda-forge-pinning 2025.05.15.18.13.30**
- **Update starlink_ast to 9.2.13**
- **MNT: Re-rendered with conda-build 25.4.2, conda-smithy 3.48.1, and conda-forge-pinning 2025.05.15.18.13.30**

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
