### PR TITLE
Update deepdiff to `>= 8.5.0`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -127,7 +127,7 @@ outputs:
         - colour-science >=0.4.6
         - configparser >=7.1.0
         - danish >=0.5.0
-        - deepdiff >=8.2.0
+        - deepdiff >=8.5.0
         - defusedxml >=0.7.1
         - deprecated >=1.2.18
         - dustmaps >=1.0.13


### PR DESCRIPTION
**Requires version bump due to new minimum dependency version**

This is a minor change to bump the required version of `deepdiff` to 8.5.0, which is the most recent release. I want to use some recently added features in [Felis](https://github.com/lsst/felis).

Felis currently has a `deepdiff` dependency which is deliberately unpinned so I am updating it here.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged. (I don't know how to do this.)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
