### PR TITLE
DM-52559:Fix Starlink_ast and add missing documenteer dep

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -71,7 +71,7 @@ python:
 rust_compiler:
 - rust
 starlink_ast:
-- 9.2.12
+- 9.2.14
 target_platform:
 - linux-64
 wcslib:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -71,7 +71,7 @@ python:
 rust_compiler:
 - rust
 starlink_ast:
-- 9.2.12
+- 9.2.14
 target_platform:
 - linux-aarch64
 wcslib:

--- a/.ci_support/migrations/starlink_ast9214.yaml
+++ b/.ci_support/migrations/starlink_ast9214.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for starlink_ast 9.2.14
+  kind: version
+  migration_number: 1
+migrator_ts: 1757056738.3256714
+starlink_ast:
+- 9.2.14

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -73,7 +73,7 @@ python:
 rust_compiler:
 - rust
 starlink_ast:
-- 9.2.12
+- 9.2.14
 target_platform:
 - osx-64
 wcslib:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -73,7 +73,7 @@ python:
 rust_compiler:
 - rust
 starlink_ast:
-- 9.2.12
+- 9.2.14
 target_platform:
 - osx-arm64
 wcslib:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -47,7 +47,7 @@ minuit2:
 ndarray:
   - '1'
 starlink_ast:
-  - '9.2.12'
+  - '9.2.14'
 wcslib:
   - '8'
 xpa:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   name: "rubin-env"
   version: "11.0.0"
-  build_number: 1
+  build_number: 2
   linux_gxx_abi_version: 1019
   osx_gxx_abi_version: 1002
 
@@ -142,7 +142,6 @@ outputs:
         - deepdiff >=8.6.1
         - defusedxml >=0.7.1
         - deprecated >=1.2.18
-        - documenteer >=2.2.0
         - dustmaps >=1.0.14
         - emcee >=3.1.6
         - esutil >=0.6.16
@@ -171,6 +170,7 @@ outputs:
         - jax >=0.7.0
         - lmfit >=1.3.4,<1.4
         - lsstdesc.coord >=1.3.0
+        - lsst-documenteer-guide >=2.2
         - lsst-ts-xml >=23.3.2
         - matplotlib-base >=3.10
         - maturin >=1.9.4
@@ -220,6 +220,7 @@ outputs:
         - skyproj >=2.1.1
         - sorcha >=1.0
         - spherematch >=0.10.2
+        - sphinxcontrib-doxylink >=1.13
         - sqlalchemy >=2.0.43
         - sqlite >=3.50.4
         - threadpoolctl >=3.6.0


### PR DESCRIPTION
- **Add lsst-documenteer-guide to recipe**
- **Update starlink_ast to 9.2.14**
- **MNT: Re-rendered with conda-smithy 3.52.2 and conda-forge-pinning 2025.09.17.06.41.22**

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
