### PR TITLE
Unpin c_blosc2, because of newer hf5plugin

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,5 +1,7 @@
 apr:
 - '1'
+c_blosc2:
+- '3.1'
 c_compiler:
 - gcc
 c_compiler_version:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,5 +1,7 @@
 apr:
 - '1'
+c_blosc2:
+- '3.1'
 c_compiler:
 - gcc
 c_compiler_version:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -4,6 +4,8 @@ MACOSX_SDK_VERSION:
 - '11.0'
 apr:
 - '1'
+c_blosc2:
+- '3.1'
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -4,6 +4,8 @@ MACOSX_SDK_VERSION:
 - '11.0'
 apr:
 - '1'
+c_blosc2:
+- '3.1'
 c_compiler:
 - clang
 c_compiler_version:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -53,8 +53,6 @@ python_impl:
 #      the `apr` package).
 apr:
   - '1'
-c_blosc2:
-  - '2'
 cffi:
   - '1'
 cfitsio:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   name: "rubin-env"
   version: "13.0.1"
-  build_number: 3
+  build_number: 5
   linux_gxx_abi_version: 1019
   osx_gxx_abi_version: 1002
 
@@ -34,7 +34,7 @@ outputs:
         - ${{ compiler('cxx') }}
         - ${{ compiler('fortran') }}
         - apr
-        - c-blosc2 >=2,<3
+        - c-blosc2
         - cffi
         - cfitsio
         - curl
@@ -192,7 +192,7 @@ outputs:
         - mpi4py >=4.1.1
         - nest-asyncio >=1.6.0
         - networkx ==3.6
-        - ngmix-core >=2.4.0
+        - ngmix-core ==2.4.0 # DM-55326
         - numexpr >=2.14.1,<3
         - numpy
         - opencv >=4.12.0
@@ -316,7 +316,7 @@ outputs:
         - gh >=2.83.1  # (*): requested by jsick long ago; nice CLI for GitHub
         - ginga >=5.4.01  # (*): numpy vis and FITS viewer
         - graphicsmagick >=1.3.45  # replaces DM-34945 imagemagick
-        - hdf5plugin >=5.1.01  # lsdb (RFC 1109)  Needed for HDF5 compression
+        - hdf5plugin >=7.0.0  # lsdb (RFC 1109)  Needed for HDF5 compression
         - holoviews >=1.21.01  # (*): cf bokeh
         - httpx >=0.28.1  # (*): ubiquitous in services, handy in notebooks
         - hvplot >=0.12.2  # (*): cf bokeh


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
