### PR TITLE
Update to 13.1

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cffi:
-- '1'
+- '2'
 cfitsio:
 - 4.6.2
 channel_sources:
@@ -51,7 +51,7 @@ liblapack:
 liblapacke:
 - 3.9.* *netlib
 libpq:
-- '18.2'
+- '18.4'
 libxml2:
 - '2.14'
 libxml2_devel:
@@ -63,7 +63,7 @@ minuit2:
 ndarray:
 - '1'
 numpy:
-- '2.3'
+- '2.4'
 openblas:
 - 0.3.*
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -11,7 +11,7 @@ c_stdlib:
 c_stdlib_version:
 - '2.17'
 cffi:
-- '1'
+- '2'
 cfitsio:
 - 4.6.2
 channel_sources:
@@ -51,7 +51,7 @@ liblapack:
 liblapacke:
 - 3.9.* *netlib
 libpq:
-- '18.2'
+- '18.4'
 libxml2:
 - '2.14'
 libxml2_devel:
@@ -63,7 +63,7 @@ minuit2:
 ndarray:
 - '1'
 numpy:
-- '2.3'
+- '2.4'
 openblas:
 - 0.3.*
 pin_run_as_build:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -15,7 +15,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 cffi:
-- '1'
+- '2'
 cfitsio:
 - 4.6.2
 channel_sources:
@@ -55,7 +55,7 @@ liblapack:
 liblapacke:
 - 3.9.* *netlib
 libpq:
-- '18.2'
+- '18.4'
 libxml2:
 - '2.14'
 libxml2_devel:
@@ -69,7 +69,7 @@ minuit2:
 ndarray:
 - '1'
 numpy:
-- '2.3'
+- '2.4'
 openblas:
 - 0.3.*
 pin_run_as_build:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -15,7 +15,7 @@ c_stdlib:
 c_stdlib_version:
 - '11.0'
 cffi:
-- '1'
+- '2'
 cfitsio:
 - 4.6.2
 channel_sources:
@@ -55,7 +55,7 @@ liblapack:
 liblapacke:
 - 3.9.* *netlib
 libpq:
-- '18.2'
+- '18.4'
 libxml2:
 - '2.14'
 libxml2_devel:
@@ -69,7 +69,7 @@ minuit2:
 ndarray:
 - '1'
 numpy:
-- '2.3'
+- '2.4'
 openblas:
 - 0.3.*
 pin_run_as_build:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -84,7 +84,7 @@ minuit2:
 ndarray:
   - '1'
 numpy:
-  - '2.3'
+  - '2.4'
 starlink_ast:
   - '9.3.1'
 wcslib:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -72,7 +72,7 @@ libboost_python_devel:
 # to get the recipe to solve. I think this is due
 # to krb5 1.22 and zeromq, but that is a total guess.
 libpq:
-  - '18.2'
+  - '18.4'
 libxml2:
   - '2.14'
 libxml2_devel:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -56,7 +56,7 @@ apr:
 c_blosc2:
   - '3.1'
 cffi:
-  - '1'
+  - '2'
 cfitsio:
   - 4.6.2
 eigen:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -53,6 +53,8 @@ python_impl:
 #      the `apr` package).
 apr:
   - '1'
+c_blosc2:
+  - '3.1'
 cffi:
   - '1'
 cfitsio:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -193,7 +193,7 @@ outputs:
         - mpi4py >=4.1.1
         - nest-asyncio >=1.6.0
         - networkx ==3.6
-        - ngmix-core ==2.4.0 # DM-55326
+        - ngmix-core >=2.4.0 # DM-55331
         - numexpr >=2.14.1,<3
         - numpy
         - opencv >=4.12.0
@@ -383,7 +383,7 @@ outputs:
         - fastparquet >=2024.11.0
         - ffmpeg >=7.1.1
         - gfal2-util >=1.9.0
-        - gh >=2
+        - gh >=2 # DM-55411
         - holoviews >=1.22.0
         - hvplot >=0.12.1
         - imagemagick >=7.1.2_3

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -178,6 +178,7 @@ outputs:
         - healsparse >=1.11.1
         - hpgeom >=1.4.0
         - htcondor >=24.0,<24.1
+        - httpx2 >=2.2.0 # RFC-1191
         - humanize >=4.14.0
         - idds-client >=2.4.1
         - idds-doma >=2.4.1

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -344,7 +344,7 @@ outputs:
         - pyshp >=3.0.2  # (*): geospatial, use unknown
         - python-snappy >=0.7.3  # DM-24304
         - python-socketio >=5.14.3  # (*): for Kafka interaction?
-        - pyvo >=1.8  # DM-16386
+        - pyvo >=1.9.1  # RFC-1189
         - regions >=0.11  # (*): astropy plugin
         - reproject >= 0.19.0  # RFC-1152
         - ripgrep >=15.1.0  # (*): fast recursive grep; seems useful
@@ -409,7 +409,7 @@ outputs:
         - pytest-profiling >=1.8.1
         - python-build >=1.3.0
         - python-gfal2 >=1.13.0
-        - pyvo >=1.8
+        - pyvo >=1.9.1  # RFC-1189
         - ripgrep >=15.1.0
         - rubin-nights >=0.8.1
         - rubin-scheduler >=3.20.1

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -333,6 +333,7 @@ outputs:
         - jupyter-ai-magic-commands >=0.0.2  # DM-49034
         - lsdb >=0.6.7  # RFC-1109
         - lsst-efd-client >=0.12.0,!=1.1.0  # (*): Used by T&S
+        - lsst-rsp >=1.0.1 # DM-55411
         - mermaid-py >=0.8.0  # RFC-1067
         - mysqlclient >=2.2.7  # (*): useful for debugging RSP databases
         - nbval >=0.11.0  # (*): Pytest notebook fixtures, useful for dev

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -113,6 +113,7 @@ outputs:
         - libboost-python-devel ${{ libboost_python_devel }}.*
         - if: not linux
           then: libcxx ${{ libcxx }}.*
+        - libgdal-core >=3.13.0 # DM-55071
         - libpq >=18,<19
         - libpq ${{ libpq }}.*
         - libxml2 ${{ libxml2 }}.*
@@ -203,7 +204,7 @@ outputs:
         - parsl ==2026.02.09
         - patch >=2.8
         - pgcli >=4.3.0
-        - photutils-base >=3
+        - photutils-base >=3 # DM-55071
         - piff >=1.6.0
         - pillow >=12.1.1
         - if: linux

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -135,7 +135,7 @@ outputs:
         # run-like
         - aiohttp <3.14 # DM-55190
         - alembic >=1.17.2
-        - astropy-base >=7.1.1,<8
+        - astropy-base >=8.0.1, <9 # RFC-1190
         - astroplan >=0.10.1
         - astroquery ==0.4.9
         - autograd >=1.8.0

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -226,6 +226,7 @@ outputs:
         - qp >=1.0.1
         - rclone >=1.71.2
         - requests >=2.32.5
+        - ruamel.yaml >=0.18 # DM-55411
         - rucio-clients >=38.5,<38.6
         - ruff ==0.14.5
         - s3fs >=2025.10.0

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   name: "rubin-env"
-  version: "13.0.1"
-  build_number: 6
+  version: "13.1.0"
+  build_number: 0
   linux_gxx_abi_version: 1019
   osx_gxx_abi_version: 1002
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -135,6 +135,7 @@ outputs:
         # run-like
         - aiohttp <3.14 # DM-55190
         - alembic >=1.17.2
+        - anyio >=4.14 # RFC-1191
         - astropy-base >=8.0.1, <9 # RFC-1190
         - astroplan >=0.10.1
         - astroquery ==0.4.9
@@ -226,6 +227,7 @@ outputs:
         - qp >=1.0.1
         - rclone >=1.71.2
         - requests >=2.32.5
+        - rich >=15.0 # RFC-1191
         - ruamel.yaml >=0.18 # DM-55411
         - rucio-clients >=38.5,<38.6
         - ruff ==0.14.5

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -404,6 +404,7 @@ outputs:
         - pep8 >=1.7.1
         - postgresql >=18,<19
         - pre-commit >=4.3.0
+        - prek >=0.4.0 # DM-55411
         - pyct >=0.6.0
         - pydocstyle >=6.3.0
         - pyflakes >=3.4.0

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -383,6 +383,7 @@ outputs:
         - fastparquet >=2024.11.0
         - ffmpeg >=7.1.1
         - gfal2-util >=1.9.0
+        - gh >=2
         - holoviews >=1.22.0
         - hvplot >=0.12.1
         - imagemagick >=7.1.2_3

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -203,7 +203,7 @@ outputs:
         - parsl ==2026.02.09
         - patch >=2.8
         - pgcli >=4.3.0
-        - photutils >=2.3.0
+        - photutils-base >=3
         - piff >=1.6.0
         - pillow >=12.1.1
         - if: linux


### PR DESCRIPTION
- **adding c_blosc2 3.1** we should upgrade to 3.2 when we get the chance, but right now it breaks everything without it being pinned
- **Replace photuils with photutils-base**
- **Adding libgdal-core 3.13** was originally a dep of photutils but the older version was affecting build
- **Bump libqq to 18.4** needed for updating libgdal-core
- **Update cffi to 2** needed for updating libgdal-core
- **Bump numpy to 2.4**
- **Add Ruamel.yaml as a direct dependency**
- **Update min for astropy to >=8.0.1,<9**
- **Updated pyvo to 1.9.1**
- **Add gh (github cli)** to dev
- **Unpin ngmix-core**
- **Add prek >=0.4.0** to dev
- **Add rich >=15 and anyio 4.14.2** was already in rubin env but now it is directly
- **Update to 13.1**

This ticket's biggest impact is the change to astropy.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
